### PR TITLE
use largest child and adjust main view and secondary view size

### DIFF
--- a/swipe-reveal-layout/src/main/java/com/chauthai/swipereveallayout/SwipeRevealLayout.java
+++ b/swipe-reveal-layout/src/main/java/com/chauthai/swipereveallayout/SwipeRevealLayout.java
@@ -338,11 +338,22 @@ public class SwipeRevealLayout extends ViewGroup {
         final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
 
-        final int measuredWidth = MeasureSpec.getSize(widthMeasureSpec);
-        final int measuredHeight = MeasureSpec.getSize(heightMeasureSpec);
-
         int desiredWidth = 0;
         int desiredHeight = 0;
+
+        // first find the largest child
+        for (int i = 0; i < getChildCount(); i++) {
+            final View child = getChildAt(i);
+            measureChild(child, widthMeasureSpec, heightMeasureSpec);
+            desiredWidth = Math.max(child.getMeasuredWidth(), desiredWidth);
+            desiredHeight = Math.max(child.getMeasuredHeight(), desiredHeight);
+        }
+        // create new measure spec using the largest child width
+        widthMeasureSpec = MeasureSpec.makeMeasureSpec(desiredWidth, widthMode);
+        heightMeasureSpec = MeasureSpec.makeMeasureSpec(desiredHeight, heightMode);
+
+        final int measuredWidth = MeasureSpec.getSize(widthMeasureSpec);
+        final int measuredHeight = MeasureSpec.getSize(heightMeasureSpec);
 
         for (int i = 0; i < getChildCount(); i++) {
             final View child = getChildAt(i);


### PR DESCRIPTION
If the main view and the secondary view have different measurement sizes, but they both have the layout_height set to match_parent, they should both expand to match the parents size.

This should fix #29 .

BR,
geo