### PR TITLE
Implemented start and end flags for Android Native RTL support.

### DIFF
--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:titleTextColor="@android:color/white"/>
 
-        <com.chauthai.swipereveallayout.SwipeRevealLayout
+    <com.chauthai.swipereveallayout.SwipeRevealLayout
             android:id="@+id/swipe_layout_1"
             android:layout_width="match_parent"
             android:layout_height="70dp"
@@ -64,7 +64,6 @@
                     android:layout_gravity="center"/>
             </FrameLayout>
         </com.chauthai.swipereveallayout.SwipeRevealLayout>
-
 
     <com.chauthai.swipereveallayout.SwipeRevealLayout
         android:id="@+id/swipe_layout_2"
@@ -190,4 +189,120 @@
                 android:layout_gravity="center"/>
         </FrameLayout>
     </com.chauthai.swipereveallayout.SwipeRevealLayout>
+
+    <com.chauthai.swipereveallayout.SwipeRevealLayout
+        android:id="@+id/swipe_layout_5"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_margin="10dp"
+
+        app:mode="normal"
+        app:dragEdge="end">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:background="@android:color/darker_gray"
+                android:textColor="@android:color/white"
+                android:text="More"
+                android:onClick="moreOnClick"/>
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:background="@android:color/holo_red_dark"
+                android:textColor="@android:color/white"
+                android:text="Delete"
+                android:onClick="deleteOnClick"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@drawable/border_solid_white"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:onClick="layoutOneOnClick">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="My Awesome Layout 5"
+                android:gravity="center"
+                android:layout_gravity="center"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="drag edege is set according ot layout direction"
+                android:gravity="center"
+                android:layout_gravity="center"/>
+        </LinearLayout>
+    </com.chauthai.swipereveallayout.SwipeRevealLayout>
+
+    <com.chauthai.swipereveallayout.SwipeRevealLayout
+        android:id="@+id/swipe_layout_6"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_margin="10dp"
+        android:background="@android:color/darker_gray"
+
+        app:mode="same_level"
+        app:dragEdge="start">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:background="@android:color/holo_green_dark"
+                android:textColor="@android:color/white"
+                android:text="Archive"
+                android:onClick="archiveOnClick"/>
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:background="@android:color/holo_blue_light"
+                android:textColor="@android:color/white"
+                android:text="Help"
+                android:onClick="helpOnClick"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@drawable/border_solid_white"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:onClick="layoutOneOnClick">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="My Awesome Layout 6"
+                android:gravity="center"
+                android:layout_gravity="center"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="drag edege is set according ot layout direction"
+                android:gravity="center"
+                android:layout_gravity="center"/>
+        </LinearLayout>
+    </com.chauthai.swipereveallayout.SwipeRevealLayout>
+
 </LinearLayout>

--- a/swipe-reveal-layout/src/main/java/com/chauthai/swipereveallayout/SwipeRevealLayout.java
+++ b/swipe-reveal-layout/src/main/java/com/chauthai/swipereveallayout/SwipeRevealLayout.java
@@ -41,6 +41,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
+import static android.content.res.Configuration.SCREENLAYOUT_LAYOUTDIR_MASK;
+import static android.content.res.Configuration.SCREENLAYOUT_LAYOUTDIR_RTL;
+
 @SuppressLint("RtlHardcoded")
 public class SwipeRevealLayout extends ViewGroup {
     // These states are used only for ViewBindHelper
@@ -57,6 +60,8 @@ public class SwipeRevealLayout extends ViewGroup {
     public static final int DRAG_EDGE_RIGHT =  0x1 << 1;
     public static final int DRAG_EDGE_TOP =    0x1 << 2;
     public static final int DRAG_EDGE_BOTTOM = 0x1 << 3;
+    public static final int DRAG_EDGE_START = 0x1 << 4;
+    public static final int DRAG_EDGE_END = 0x1 << 5;
 
     /**
      * The secondary view will be under the main view.
@@ -518,7 +523,17 @@ public class SwipeRevealLayout extends ViewGroup {
      *                 </ul>
      */
     public void setDragEdge(int dragEdge) {
-        mDragEdge = dragEdge;
+        switch (dragEdge){
+            case DRAG_EDGE_START:
+                mDragEdge = isRTL() ? DRAG_EDGE_RIGHT : DRAG_EDGE_LEFT;
+                break;
+            case DRAG_EDGE_END:
+                mDragEdge = isRTL() ? DRAG_EDGE_LEFT : DRAG_EDGE_RIGHT;
+                break;
+            default:
+                mDragEdge = dragEdge;
+                break;
+        }
     }
 
     /**
@@ -692,7 +707,7 @@ public class SwipeRevealLayout extends ViewGroup {
                     0, 0
             );
 
-            mDragEdge = a.getInteger(R.styleable.SwipeRevealLayout_dragEdge, DRAG_EDGE_LEFT);
+            setDragEdge(a.getInteger(R.styleable.SwipeRevealLayout_dragEdge, DRAG_EDGE_LEFT));
             mMinFlingVelocity = a.getInteger(R.styleable.SwipeRevealLayout_flingVelocity, DEFAULT_MIN_FLING_VELOCITY);
             mMode = a.getInteger(R.styleable.SwipeRevealLayout_mode, MODE_NORMAL);
 
@@ -1067,5 +1082,9 @@ public class SwipeRevealLayout extends ViewGroup {
         Resources resources = getContext().getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();
         return (int) (dp * ((float) metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT));
+    }
+
+    private boolean isRTL(){
+        return (getResources().getConfiguration().screenLayout & SCREENLAYOUT_LAYOUTDIR_MASK) == SCREENLAYOUT_LAYOUTDIR_RTL;
     }
 }

--- a/swipe-reveal-layout/src/main/res/values/attrs.xml
+++ b/swipe-reveal-layout/src/main/res/values/attrs.xml
@@ -7,6 +7,8 @@
             <flag name="right" value="2" />
             <flag name="top" value="4" />
             <flag name="bottom" value="8" />
+            <flag name="start" value="16" />
+            <flag name="end" value="32" />
         </attr>
         
         <attr name="mode">


### PR DESCRIPTION
I've implemented this feature to take advantage of RTL layout mirroring native support and to change drag edge according to layout direction.

To use this feature you should simply replace "left/right" dragEdge property to "start/end" equivalents.